### PR TITLE
fmtm stepper fix

### DIFF
--- a/packages/web-forms/src/components/QuestionStepper.vue
+++ b/packages/web-forms/src/components/QuestionStepper.vue
@@ -60,7 +60,7 @@ const steps = computed(() =>
 
 // Handle stepper state
 const firstStep = 0;
-const finalStep = steps.value.length;
+const finalStep = computed(() => steps.value.length - 1);
 const currentStep = ref(firstStep);
 const submitPressed = ref(false);
 provide('submitPressed', submitPressed);


### PR DESCRIPTION
finalStep wasn't being recomputed but the number of steps is dynamic, changing based on what was selected in previous steps.  For example, if you select that a building exists, additional steps will be added.  Without the fix, the "send" button will be shown earlier than expected and not allow you to reach the final steps.

## I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Not applicable

## What else has been done to verify that this works as intended?
I'm working on fmtm, so I've used this new code in fmtm to verify that it works

## Why is this the best possible solution? Were any other approaches considered?

## How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

## Do we need any specific form for testing your changes? If so, please attach one.

## What's changed
