### PR TITLE
fixed issue #2414 (part 1), replacing text with icons

### DIFF
--- a/packages/web-forms/src/components/QuestionStepper.vue
+++ b/packages/web-forms/src/components/QuestionStepper.vue
@@ -144,10 +144,16 @@ const prevStep = () => {
 
     <div class="navigation-button-group">
         <!-- If swapping to arrows: 🡨 🡪 -->
-        <Button v-if="currentStep > firstStep" class="navigation-button" label="Back" @click="prevStep" rounded outlined />
-        <Button v-if="currentStep === finalStep" class="navigation-button" label="Send" @click="allFieldsValid ? emit('sendFormFromStepper') : null" rounded />
+        <Button v-if="currentStep > firstStep" class="navigation-button" @click="prevStep" rounded outlined>
+					<span class="icon-keyboard_arrow_left"></span>
+				</Button>
+        <Button v-if="currentStep === finalStep" class="navigation-button" @click="allFieldsValid ? emit('sendFormFromStepper') : null" rounded>
+					<span class="icon-cloud_upload"></span>
+				</Button>
         <!-- Note the button ordering is important here as we use a last-child selector for styling -->
-        <Button v-if="currentStep < finalStep" class="navigation-button" label="Next" @click="nextStep" rounded outlined />
+        <Button v-if="currentStep < finalStep" class="navigation-button" @click="nextStep" rounded outlined>
+					<span class="icon-keyboard_arrow_right"></span>
+				</Button>
     </div>
 </template>
 
@@ -190,5 +196,10 @@ const prevStep = () => {
     padding-left: 3rem;
     padding-right: 3rem;
     font-size: 1rem;
+}
+
+.navigation-button > span {
+		font-weight: bold;
+		font-size: 30px;	
 }
 </style>


### PR DESCRIPTION
Addresses #2414

### I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?

### Why is this the best possible solution? Were any other approaches considered?
Considered adding new icons to the icon set for getodk/web-forms, but thought that would greatly increase complexity, so thought to phase 2 that.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

### Do we need any specific form for testing your changes? If so, please attach one.


### What's changed
