### PR TITLE
Add boolean flag to hide uploaded image preview 

### DIFF
--- a/packages/web-forms/src/components/OdkWebForm.vue
+++ b/packages/web-forms/src/components/OdkWebForm.vue
@@ -51,10 +51,13 @@ export interface OdkWebFormsProps {
 	 * closer to Collect.
 	 */
 	readonly stepperLayout?: boolean;
+
+	readonly disableUploadImagePreview: boolean;
 }
 
 const props = withDefaults(defineProps<OdkWebFormsProps>(), {
 	stepperLayout: false,
+	disableUploadImagePreview: false,
 });
 
 // default header to true
@@ -198,6 +201,7 @@ const handleSubmit = (currentState: FormStateSuccessResult) => {
 const validationErrorMessagePopover = ref<ComponentPublicInstance | null>(null);
 
 provide('submitPressed', submitPressed);
+provide('disableUploadImagePreview', props.disableUploadImagePreview);
 
 const validationErrorMessage = computed(() => {
 	const violationLength = state.value.root?.validationState.violations.length ?? 0;

--- a/packages/web-forms/src/components/controls/Upload/UploadImagePreview.vue
+++ b/packages/web-forms/src/components/controls/Upload/UploadImagePreview.vue
@@ -3,12 +3,14 @@ import type { ObjectURL } from '@getodk/common/lib/web-compat/url.ts';
 import { createObjectURL, revokeObjectURL } from '@getodk/common/lib/web-compat/url.ts';
 import type { UploadNode } from '@getodk/xforms-engine';
 import Button from 'primevue/button';
-import { computed, ref, triggerRef, watchEffect } from 'vue';
+import { computed, ref, triggerRef, watchEffect, inject } from 'vue';
 
 export interface UploadImagePreviewProps {
 	readonly question: UploadNode;
 	readonly isDisabled: boolean;
 }
+
+const disableUploadImagePreview = inject<boolean>('disableUploadImagePreview', false);
 
 const props = defineProps<UploadImagePreviewProps>();
 
@@ -50,6 +52,8 @@ const isSmallImage = computed(() => {
 	return naturalWidth < SMALL_IMAGE_SIZE && naturalHeight < SMALL_IMAGE_SIZE;
 });
 
+const imageName = computed(() => props.question.currentState.value?.name);
+
 const imageURL = computed((previous: ObjectURL | null = null) => {
 	if (previous != null) {
 		revokeObjectURL(previous);
@@ -74,7 +78,10 @@ watchEffect(() => {
 </script>
 
 <template>
-	<div v-if="imageURL" class="preview-captured-image" :class="{ 'small-image': isSmallImage }">
+	<div v-if="disableUploadImagePreview">
+		<span v-text="imageName"></span>
+	</div>
+	<div v-else-if="imageURL" class="preview-captured-image" :class="{ 'small-image': isSmallImage }">
 		<Button v-if="!isDisabled" severity="secondary" outlined class="clear-button" @click="emit('clear')">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Closes #

### I have verified this PR works in these browsers (latest versions):

- [X] Chrome
- [ ] Firefox
- [ ] Safari (macOS)
- [ ] Safari (iOS)
- [ ] Chrome for Android
- [ ] Not applicable

### What else has been done to verify that this works as intended?
Tests in Chrome with fmtm

### Why is this the best possible solution? Were any other approaches considered?
Lightweight approach.  Used provide/inject in order to avoid having to pass prop down through multiple components.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
If the option isn't used, it just defaults to false (default behavior of displaying preview image)

### Do we need any specific form for testing your changes? If so, please attach one.

### What's changed
Basically can instantiate OdkWebForm with a new option like 
```js
new OdkWebForm({
   // ...
  disableUploadImagePreview: true
})`